### PR TITLE
[167756788] AdColony - Android - SDK causes the app to crash when trying...

### DIFF
--- a/android-adapters/7.0.2/adapters.info
+++ b/android-adapters/7.0.2/adapters.info
@@ -15,8 +15,8 @@
       {
          "qualifiedName":"com.sponsorpay.mediation.UnityAdsMediationAdapter",
          "versions":[
-            "2.1.0",
-            "2.2.2"
+            "2.2.0",
+            "2.2.1"
          ]
       },
       {
@@ -26,7 +26,8 @@
             "2.1.0",
             "2.1.1",
             "2.2.0",
-            "2.2.1"
+            "2.2.1",
+            "2.2.2"
          ]
       },
       {
@@ -34,7 +35,8 @@
          "versions":[
             "2.0.0",
             "2.1.0",
-            "2.1.1"
+            "2.1.1",
+            "2.1.2"
          ]
       },
       {
@@ -42,16 +44,14 @@
          "versions":[
             "1.0.0",
             "1.0.1",
-            "1.1.0"
+            "1.1.0",
+            "1.1.1"
          ]
       },
       {
          "qualifiedName":"com.sponsorpay.mediation.AppLovinMediationAdapter",
          "versions":[
-            "1.1.0",
-            "1.2.0",
-            "1.3.0",
-            "1.3.1"
+            "1.4.1"
          ]
       },
       {
@@ -83,15 +83,13 @@
       {
          "qualifiedName": "com.sponsorpay.mediation.HyprMXMediationAdapter",
          "versions": [
-            "1.0.0",
-            "1.0.1"
+            "1.0.2"
          ]
       },
       {
          "qualifiedName":"com.sponsorpay.mediation.TremorMediationAdapter",
          "versions":[
-            "1.0.0",
-            "1.1.0"
+            "1.0.0"
          ]
       },
       {

--- a/android-adapters/7.1.0/adapters.info
+++ b/android-adapters/7.1.0/adapters.info
@@ -3,7 +3,7 @@
       {
          "qualifiedName":"com.sponsorpay.mediation.AdColonyMediationAdapter",
          "versions":[
-            "1.1.1"
+            "1.1.3"
          ]
       },
       {

--- a/android-adapters/7.1.0/adapters.info
+++ b/android-adapters/7.1.0/adapters.info
@@ -3,7 +3,7 @@
       {
          "qualifiedName":"com.sponsorpay.mediation.AdColonyMediationAdapter",
          "versions":[
-            "1.1.3"
+            "1.1.1"
          ]
       },
       {
@@ -15,8 +15,8 @@
       {
          "qualifiedName":"com.sponsorpay.mediation.UnityAdsMediationAdapter",
          "versions":[
-            "2.1.0",
-            "2.2.2"
+            "2.2.0",
+            "2.2.1"
          ]
       },
       {
@@ -26,7 +26,8 @@
             "2.1.0",
             "2.1.1",
             "2.2.0",
-            "2.2.1"
+            "2.2.1",
+            "2.2.2"
          ]
       },
       {
@@ -34,7 +35,8 @@
          "versions":[
             "2.0.0",
             "2.1.0",
-            "2.1.1"
+            "2.1.1",
+            "2.1.2"
          ]
       },
       {
@@ -42,16 +44,14 @@
          "versions":[
             "1.0.0",
             "1.0.1",
-            "1.1.0"
+            "1.1.0",
+            "1.1.1"
          ]
       },
       {
          "qualifiedName":"com.sponsorpay.mediation.AppLovinMediationAdapter",
          "versions":[
-            "1.1.0",
-            "1.2.0",
-            "1.3.0",
-            "1.3.1"
+            "1.4.1"
          ]
       },
       {
@@ -83,15 +83,13 @@
       {
          "qualifiedName": "com.sponsorpay.mediation.HyprMXMediationAdapter",
          "versions": [
-            "1.0.0",
-            "1.0.1"
+            "1.0.2"
          ]
       },
       {
          "qualifiedName":"com.sponsorpay.mediation.TremorMediationAdapter",
          "versions":[
-            "1.0.0",
-            "1.1.0"
+            "1.0.0"
          ]
       },
       {


### PR DESCRIPTION
... to show an interstitial of AdColony when zone type is set to V4VC

Changed supported versions of AdColony adapter.